### PR TITLE
broadcast for admins

### DIFF
--- a/daily_word_bot/utils.py
+++ b/daily_word_bot/utils.py
@@ -49,6 +49,17 @@ def highlight_in_sentence(s: str, terms: str) -> str:
     return s
 
 
+broadcast_sep = f"\n{'-'*10}\n"
+
+
+def build_broadcast_preview_msg(msg: str) -> str:
+    return f"Broadcast message preview:{broadcast_sep}{msg}{broadcast_sep}Do you want to send it?"
+
+
+def get_broadcast_msg_from_preview(msg: str) -> str:
+    return msg.split(broadcast_sep)[1]
+
+
 def build_word_msg(word_data: dict) -> str:
 
     examples: list = (word_data.get("examples") or [])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -104,3 +104,16 @@ def test_build_levels_answer():
         index = answer.get('reply_markup').inline_keyboard.index(button)
         tc.assertEqual(button[0].text, expected_reply_markup.inline_keyboard[index][0].text)
         tc.assertEqual(button[0].callback_data, expected_reply_markup.inline_keyboard[index][0].callback_data)
+
+
+def test_build_broadcast_preview_msg():
+    msg = utils.build_broadcast_preview_msg("test msg")
+    expected = "Broadcast message preview:\n----------\ntest msg\n----------\nDo you want to send it?"
+    assert msg == expected
+
+
+def test_get_broadcast_msg_from_preview():
+    preview_msg = "Broadcast message preview:\n----------\ntest msg\n----------\nDo you want to send it?"
+    msg = utils.get_broadcast_msg_from_preview(preview_msg)
+    expected = "test msg"
+    return msg == expected


### PR DESCRIPTION
- added `admins_only ` decorator for protecting admin msg callbacks with admin permissions
- added conversation for broadcast: so admins can send a broadcast msg to all active users